### PR TITLE
Make it work with every Gnome Shell 3.0 release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
  "uuid": "pidgin@gnome-shell-extensions.gnome.org",
  "name": "Pidgin IM Integration",
  "description": "Display Pidgin chats as notifications in the Shell message tray.",
- "shell-version": [ "3.0.1" ],
+ "shell-version": [ "3.0" ],
  "localedir": "/usr/share/locale",
  "url": "https://github.com/kagesenshi/gnome-shell-extensions-pidgin"
 }


### PR DESCRIPTION
The actual version of the plugin only work with version 3.0.1 of the plugin, resulting in a version mismatch error if you use a newer version.
I don't see a point why we should not use '3.0' as required shell version.
