### PR TITLE
Compatability with gnome-shell 3.1.91

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -101,6 +101,7 @@ Source.prototype = {
         this._notification.enableScrolling(true);
 
         proxy.PurpleConversationGetTitleRemote(this._conversation, Lang.bind(this, this._async_set_title));
+        if (chat) proxy.PurpleConvChatRemote(this._conversation, Lang.bind(this, this._async_set_conversation_im));
     },
 
     _async_set_author_buddy: function (author_buddy) {
@@ -221,7 +222,12 @@ Source.prototype = {
     respond: function(text) {
         let proxy = this._client.proxy();
         let _text = GLib.markup_escape_text(text, -1);
-        proxy.PurpleConvImSendRemote(this._conversation_im, _text);
+        if(this._chat){
+        	proxy.PurpleConvChatSendRemote(this._conversation_im, _text);
+        }
+        else{
+        	proxy.PurpleConvImSendRemote(this._conversation_im, _text);
+        }
     },
 
     _onBuddyStatusChange: function (emitter, buddy, old_status_id, new_status_id) {

--- a/extension.js
+++ b/extension.js
@@ -46,7 +46,7 @@ function _fixText(text) {
 }
 
 PidginNotification.prototype = {
-    __proto__: TelepathyClient.Notification.prototype,
+    __proto__: TelepathyClient.ChatNotification.prototype,
 
     appendMessage: function(message, noTimestamp, styles) {
         let messageBody = _fixText(message.text);
@@ -62,7 +62,7 @@ function PidginChatNotification(source) {
 }
 
 PidginChatNotification.prototype = {
-    __proto__: TelepathyClient.Notification.prototype,
+    __proto__: TelepathyClient.ChatNotification.prototype,
 
     // monkey-patched from TelepathyClient.Notification
     _init: function(source) {
@@ -467,8 +467,17 @@ PidginClient.prototype = {
     }
 }
 
+let _pidginClient = null;
 
-function main(metadata) {
+function init(metadata) {
     imports.gettext.bindtextdomain('gnome-shell-extensions', metadata.localedir);
-    let client = new PidginClient();
+}
+
+function enable() {
+    _pidginClient = new PidginClient();
+}
+
+function disable() {
+	_pidginClient.destroy();
+	_pidingClient = null;
 }

--- a/extension.js
+++ b/extension.js
@@ -21,7 +21,7 @@ const Tp = imports.gi.TelepathyGLib;
 const Gettext = imports.gettext.domain('gnome-shell-extensions');
 const _ = Gettext.gettext;
 
-function wrappedText(text, sender, timestamp, direction) {
+function wrappedText(text, sender, timestamp, direction, chat) {
     let currentTime = (Date.now() / 1000);
 	let type = Tp.ChannelTextMessageType.NORMAL;
 
@@ -30,6 +30,9 @@ function wrappedText(text, sender, timestamp, direction) {
     }
 	
 	text = _fixText(text);
+	if (chat){
+		text = sender + ": " + text;
+	}
 	if (text.substr(0, 3) == '/me' && direction != TelepathyClient.NotificationDirection.SENT) {
 		text = text.substr(4);
 		type = Tp.ChannelTextMessageType.ACTION;
@@ -153,7 +156,7 @@ Source.prototype = {
             direction = TelepathyClient.NotificationDirection.RECEIVED;
         }
 
-        let message = wrappedText(this._initialMessage, this._author, null, direction);
+        let message = wrappedText(this._initialMessage, this._author, null, direction, this._chat);
         this._notification.appendMessage(message, false);
 
         if (this._chat) {
@@ -355,7 +358,9 @@ const PidginIface = {
         {name: 'PurpleBuddyIconGetFullPath', inSignature: 'i', outSignature: 's'},
         {name: 'PurpleBuddyGetIcon', inSignature: 'i', outSignature: 'i'},
         {name: 'PurpleConvImSend', inSignature: 'is', outSignature: ''},
+        {name: 'PurpleConvChatSend', inSignature: 'is', outSignature: ''},
         {name: 'PurpleConvIm', inSignature: 'i', outSignature: 'i'},
+        {name: 'PurpleConvChat', inSignature: 'i', outSignature: 'i'},
         {name: 'PurpleConvImGetIcon', inSignature: 'i', outSignature: 'i'},
         {name: 'PurpleConversationGetName', inSignature: 'i', outSignature: 's'},
         {name: 'PurpleConversationGetAccount', inSignature: 'i', outSignature: 's'},

--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,7 @@ function wrappedText(text, sender, timestamp, direction, chat) {
     }
 	
 	text = _fixText(text);
-	if (chat){
+	if (chat && direction != TelepathyClient.NotificationDirection.SENT){
 		text = sender + ": " + text;
 	}
 	if (text.substr(0, 3) == '/me' && direction != TelepathyClient.NotificationDirection.SENT) {
@@ -156,7 +156,7 @@ Source.prototype = {
         } else if (this._initialFlag == 2) {
             direction = TelepathyClient.NotificationDirection.RECEIVED;
         }
-
+        
         let message = wrappedText(this._initialMessage, this._author, null, direction, this._chat);
         this._notification.appendMessage(message, false);
 
@@ -308,17 +308,22 @@ Source.prototype = {
     },
 
     _onDisplayedChatMessage: function(emitter, account, author, text, conversation, flag) {
-    	
+    	global.log(flag);
         if (text && (this._conversation == conversation) && (flag & 3) == 2) {
             // accept messages from people who sent us something with our nick in it
             if ((flag & 32) == 32) {
                 this._authors[author] = true;
             }
             if (author in this._authors) {
-                let message = wrappedText(author + ": " + text, author, null, TelepathyClient.NotificationDirection.RECEIVED);
+                let message = wrappedText(text, author, null, TelepathyClient.NotificationDirection.RECEIVED, this._chat);
                 this._notification.appendMessage(message, false);
                 this.notify();
             }
+        }
+        else if(flag == 1){
+            let message = wrappedText(text, author, null, TelepathyClient.NotificationDirection.SENT, this._chat);
+            this._notification.appendMessage(message, false);
+            this.notify();
         }
 
     },

--- a/extension.js
+++ b/extension.js
@@ -308,14 +308,14 @@ Source.prototype = {
     },
 
     _onDisplayedChatMessage: function(emitter, account, author, text, conversation, flag) {
-
+    	
         if (text && (this._conversation == conversation) && (flag & 3) == 2) {
             // accept messages from people who sent us something with our nick in it
             if ((flag & 32) == 32) {
                 this._authors[author] = true;
             }
             if (author in this._authors) {
-                let message = wrappedText(text, author, null, TelepathyClient.NotificationDirection.RECEIVED);
+                let message = wrappedText(author + ": " + text, author, null, TelepathyClient.NotificationDirection.RECEIVED);
                 this._notification.appendMessage(message, false);
                 this.notify();
             }

--- a/extension.js
+++ b/extension.js
@@ -211,7 +211,7 @@ Source.prototype = {
     _async_notify: function (stats) {
         if (!stats) {
             MessageTray.Source.prototype.notify.call(this, this._notification);
-/*            this._notification.scrollTo(St.Side.BOTTOM);*/
+            this._notification.scrollTo(St.Side.BOTTOM);
         }
     },
 
@@ -419,7 +419,7 @@ PidginClient.prototype = {
     _messageDisplayed: function(emitter, account, author, message, conversation, flag) {
 
         // only trigger on message received/message sent
-        if (flag != 2) return;
+        if (flag != 2 && flag != 1) return;
 
         if (conversation) {
             let source = this._sources[conversation];

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
  "uuid": "pidgin@gnome-shell-extensions.gnome.org",
  "name": "Pidgin IM Integration",
  "description": "Display Pidgin chats as notifications in the Shell message tray.",
- "shell-version": [ "3.0" ],
+ "shell-version": [ "3.1.91" ],
  "localedir": "/usr/share/locale",
  "url": "https://github.com/kagesenshi/gnome-shell-extensions-pidgin"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
  "uuid": "pidgin@gnome-shell-extensions.gnome.org",
  "name": "Pidgin IM Integration",
  "description": "Display Pidgin chats as notifications in the Shell message tray.",
- "shell-version": [ "3.1.91" ],
+ "shell-version": [ "3.1.91", "3.1.92", "3.2" ],
  "localedir": "/usr/share/locale",
  "url": "https://github.com/kagesenshi/gnome-shell-extensions-pidgin"
 }


### PR DESCRIPTION
With the changes made the extension now works with gnome-shell 3.1.91. I haven't tested everything (like chat rooms) but its working fine for regular messages and notifications.
