### PR TITLE
Changed output of escape characters

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -218,7 +218,11 @@ function wrappedText(text, sender, timestamp, direction) {
 function _fixText(text) {
     // remove all tags
     let _text = html_entity_decode(text.replace(/<\/?[^>]+(>|$)/g, ""));
-    _text = _text.replace('&apos;', '\''); // Gets past html_entity_decode somehow.
+    _text = _text.replace("&lt;", "<"); //get away from html
+    _text = _text.replace("&gt;", ">");
+    _text = _text.replace("&apos;", "'");
+    _text = _text.replace("&quot;", "\"")
+    _text = _text.replace("&amp;", "\&");
     return _text;
 }
 

--- a/extension.js
+++ b/extension.js
@@ -214,15 +214,15 @@ function wrappedText(text, sender, timestamp, direction) {
     };
 }
 
-
 function _fixText(text) {
     // remove all tags
-    let _text = html_entity_decode(text.replace(/<\/?[^>]+(>|$)/g, ""));
-    _text = _text.replace("&lt;", "<"); //get away from html
-    _text = _text.replace("&gt;", ">");
-    _text = _text.replace("&apos;", "'");
-    _text = _text.replace("&quot;", "\"")
-    _text = _text.replace("&amp;", "\&");
+    let _text = text.replace(/<\/?[^>]+(>|$)/g, "");
+    _text = _text.replace(/&lt;/g, "<");
+    _text = _text.replace(/&gt;/g, ">");
+    _text = _text.replace(/&apos;/g, "'");
+    _text = _text.replace(/&quot;/g, "\"")
+    _text = _text.replace(/&amp;/g, "&");
+
     return _text;
 }
 


### PR DESCRIPTION
Various HTML escape characters (', ", <, >, &) were being outputted wrong. Added fix for these into _fixText function in extensions.js.
