### PR TITLE
add compatibility to both 3.2 and 3.4

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -694,7 +694,7 @@ PidginClient.prototype = {
     }
 }
 
-function init(metadata) {
-    imports.gettext.bindtextdomain('gnome-shell-extensions', imports.misc.config.LOCALEDIR);
+function init(metaObject) {
+    imports.gettext.bindtextdomain('gnome-shell-extensions', metaObject.metadata.localedir);
     return new PidginClient();
 }

--- a/extension.js
+++ b/extension.js
@@ -695,6 +695,21 @@ PidginClient.prototype = {
 }
 
 function init(metaObject) {
-    imports.gettext.bindtextdomain('gnome-shell-extensions', metaObject.metadata.localedir);
+    var LocalDir;
+
+    // gnome-shell 3.4
+    if ("metadata" in metaObject) {
+        LocalDir = metaObject.metadata.localedir;
+    }
+    // gnome-shell 3.2
+    else if ("localedir" in metaObject) {
+        LocalDir = metaObject.localedir;
+    }
+    // don't know what happends, hardcode it.
+    else {
+        LocalDir = "/usr/share/locale";
+    }
+
+    imports.gettext.bindtextdomain('gnome-shell-extensions', LocalDir);
     return new PidginClient();
 }


### PR DESCRIPTION
the patch i submitted in issue #21 works for 3.4 but breaks in 3.2.

I look into documents about the argument passed to init(), it seems changed since 3.4, so I let codes to determine which to use. 
